### PR TITLE
Fix default read group to respect SAM spec

### DIFF
--- a/bwameth.py
+++ b/bwameth.py
@@ -260,7 +260,7 @@ def bwa_mem(fa, mfq, extra_args, threads=1, rg=None,
         raise BWAMethException("first run bwameth.py index %s" % fa)
 
     if not rg is None and not rg.startswith('@RG'):
-        rg = '@RG\tID:{rg}\tSM:{rg}'.format(rg=rg)
+        rg = '@RG\\tID:{rg}\\tSM:{rg}'.format(rg=rg)
 
     # penalize clipping and unpaired. lower penalty on mismatches (-B)
     cmd = "|bwa mem -T 40 -B 2 -L 10 -CM "


### PR DESCRIPTION
When using bwameth with bwa >=0.7.16 and not specifying `--read-group`, I'm getting the error already reported in

https://github.com/brentp/bwa-meth/issues/44#issuecomment-334573644

i.e.:

```
[E::bwa_set_rg] the read group line contained literal <tab> characters -- replace with escaped tabs: \t
Traceback (most recent call last):
  File "/path/bin/bwa-meth-0.10/bwameth.py", line 601, in <module>
    main(sys.argv[1:])
  File "/path/bin/bwa-meth-0.10/bwameth.py", line 586, in main
    set_as_failed=args.set_as_failed)
  File "/path/bwa-meth-0.10/bwameth.py", line 259, in bwa_mem
    as_bam(cmd, fa, prefix, calmd, set_as_failed)
  File "/path/bin/bwa-meth-0.10/bwameth.py", line 293, in as_bam
    raise Exception("bad or empty fastqs")
Exception: bad or empty
```

This is due to the following change in bwa:

https://github.com/lh3/bwa/pull/84