### PR TITLE
c2t: don't exhaust memory when input files aren't interleaved.

### DIFF
--- a/bwameth.py
+++ b/bwameth.py
@@ -101,7 +101,7 @@ def convert_reads(fq1s, fq2s, out=sys.stdout):
         if already_interleaved:
             selected_iter = q1_iter
         else:
-            selected_iter = chain(*izip(q1_iter, q2_iter))
+            selected_iter = chain.from_iterable(izip(q1_iter, q2_iter))
 
         for read_i, (name, seq, _, qual) in enumerate(selected_iter):
             if name is None: continue


### PR DESCRIPTION
Use the lazy evaluation version, chain.from_iterable(), instead of first
extracting all items in the iterable to pass as arguments to chain().