### PR TITLE
Support for BWA-MEM2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 bwa-meth
 ========
 
-Fast and accurate alignment of BS-Seq reads.
+Fast and accurante alignment of BS-Seq reads.
 
 ## NOTE!!!
 
@@ -56,10 +56,13 @@ Without installation, you can use as `python bwameth.py` with install, the
 command is `bwameth.py`.
 
 The commands:
+```bash
+bwameth.py index $REF #Indexes with BWA-MEM (default)
+    #OR
+bwameth.py index mem2 $REF #Indexes with BWA-MEM2
 
-    bwameth.py index $REF
-    bwameth.py --reference $REF some_R1.fastq.gz some_R2.fastq.gz > some.output.sam
-
+bwameth.py --reference $REF some_R1.fastq.gz some_R2.fastq.gz > some.output.sam
+```
 will create `some.output.bam` and `some.output.bam.bai`.
 To align single end-reads, specify only 1 file.
 
@@ -112,7 +115,7 @@ Dependencies
 
  + samtools command on the `$PATH` (https://github.com/samtools/samtools)
 
- + bwa mem from: https://github.com/lh3/bwa
+ + bwa mem from: https://github.com/lh3/bwa OR bwa-mem2 from: https://github.com/bwa-mem2/bwa-mem2
 
 
 usage
@@ -123,7 +126,9 @@ Index
 
 One time only, you need to index a reference sequence.
 
-    bwameth.py index $REFERENCE
+    bwameth.py index $REF #Indexes with BWA-MEM (default)
+    #OR
+    bwameth.py index mem2 $REF #Indexes with BWA-MEM2
 
 If your reference is `some.fasta`, this will create `some.c2t.fasta`
 and all of the bwa indexes associated with it.
@@ -140,10 +145,19 @@ The output will pass will have the reads in the correct location (flipped from G
 Handles clipped alignments and indels correctly. Fastqs can be gzipped
 or not.
 
-The command above will be sent to BWA to do the work as something like:
+The command above will be sent to BWA-MEM or BWA-MEM2 to do the work as something like:
 
-    bwa mem -L 25 -pCM -t 15  $REFERENCE.c2t.fa \
+```bash
+bwa mem -L 25 -pCM -t 15  $REFERENCE.c2t.fa \
             '<python bwameth.py c2t $FQ1 $FQ2'
+
+              #OR
+
+bwa-mem2 mem -L 25 -pCM -t 15  $REFERENCE.c2t.fa \
+            '<python bwameth.py c2t $FQ1 $FQ2'
+```
+
+Index from BWA-MEM or BWA-MEM2 is auto detected and the corresponding aligner is chosen.
 
 So the converted reads are streamed directly to bwa and **never written
 to disk**. The output from that is modified by `bwa-meth` and streamed

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ The commands:
 ```bash
 bwameth.py index $REF #Indexes with BWA-MEM (default)
     #OR
-bwameth.py index mem2 $REF #Indexes with BWA-MEM2
+bwameth.py index-mem2 $REF #Indexes with BWA-MEM2
 
 bwameth.py --reference $REF some_R1.fastq.gz some_R2.fastq.gz > some.output.sam
 ```
@@ -128,7 +128,7 @@ One time only, you need to index a reference sequence.
 
     bwameth.py index $REF #Indexes with BWA-MEM (default)
     #OR
-    bwameth.py index mem2 $REF #Indexes with BWA-MEM2
+    bwameth.py index-mem2 $REF #Indexes with BWA-MEM2
 
 If your reference is `some.fasta`, this will create `some.c2t.fasta`
 and all of the bwa indexes associated with it.

--- a/bwameth.py
+++ b/bwameth.py
@@ -22,7 +22,7 @@ bwa-meth supports indexes from BWA-MEM and BWA-MEM2.
 
     bwameth.py index $REF #For BWA-MEM (default)
     OR
-    bwameth.py index mem2 $REF #For BWA-MEM2
+    bwameth.py index-mem2 $REF #For BWA-MEM2
 """
 from __future__ import print_function
 import tempfile
@@ -346,7 +346,7 @@ def bwa_mem(fa, fq_convert_cmd, extra_args, threads=1, rg=None,
         sys.stderr.write("Found BWA MEM2 index\n")
         
     else:
-        raise BWAMethException("first run bwameth.py index %s OR bwameth.py index mem2 %s" % (fa, fa))
+        raise BWAMethException("first run bwameth.py index %s OR bwameth.py index-mem2 %s" % (fa, fa))
 
 
     if not rg is None and not rg.startswith('@RG'):
@@ -505,12 +505,16 @@ def convert_fqs(fqs):
 
 def main(args=sys.argv[1:]):
     
-    if len(args) > 0 and args[0] == "index":
-        if len(args) == 2:
+    if len(args) > 0:
+        assert len(args) == 2, ("must specify fasta as 2nd argument")
+        if args[0] == "index":
             sys.exit(bwa_index(convert_fasta(args[1])))
-        elif len(args) == 3:
-            assert args[1] == "mem2", ("must specify mem2 as first argument and fasta as 2nd argument")
-            sys.exit(bwa_index(convert_fasta(args[2]), ver = "mem2"))
+        elif args[0] == "index-mem2":
+            sys.exit(bwa_index(convert_fasta(args[1]), ver = "mem2"))
+        else:
+            sys.stderr.write("ERROR! First argument can only be: index OR index-mem2\n")
+            sys.exit(1)
+
 
     if len(args) > 0 and args[0] == "c2t":
         sys.exit(convert_reads(args[1], args[2]))


### PR DESCRIPTION
Hi,

This PR adds support for aligning with [BWA-MEM2](https://github.com/bwa-mem2/bwa-mem2) aligner which offers significant speed with identical alignment to BWA-MEM

### Usage:

Only change is indexing step which requires `mem2` tag, in the absence of which bwa-meth uses mem.

```bash
bwameth.py index $REF #Indexes with BWA-MEM (default)
    #OR
bwameth.py index mem2 $REF #Indexes with BWA-MEM2
```
Alignment step does not change and, the aligner MEM or MEM2 is automatically chosen based on the index type
```bash
bwameth.py --reference $REF some_R1.fastq.gz some_R2.fastq.gz > some.output.sam
```

### Benchmark:
I have tested it on 250K, 150bp paired-end reads. 
Runtime bench-marked with [hyperfine](https://github.com/sharkdp/hyperfine)

```bash

$ cat gen_mem1_sh.sh 
#!/usr/bin/env bash
python ../bwameth.py --reference ../bwameth_idx/bwamem1/chm13.draft_v1.1.fasta ../fastq/R1.fq.gz ../fastq/R2.fq.gz > mem1.sam

$ cat gen_mem2_sh.sh 
#!/usr/bin/env bash
python ../bwameth.py --reference ../bwameth_idx/bwamem2/chm13.draft_v1.1.fasta ../fastq/R1.fq.gz ../fastq/R2.fq.gz > mem2.sam


$ hyperfine --warmup 2 './gen_mem1_sh.sh' './gen_mem2_sh.sh'
Benchmark #1: ./gen_mem1_sh.sh
  Time (mean ± σ):     173.818 s ±  1.141 s    [User: 980.671 s, System: 8.116 s]
  Range (min … max):   171.717 s … 175.572 s    10 runs
 
Benchmark #2: ./gen_mem2_sh.sh
  Time (mean ± σ):     104.469 s ±  0.473 s    [User: 477.614 s, System: 21.802 s]
  Range (min … max):   103.605 s … 104.972 s    10 runs
 
Summary
  './gen_mem2_sh.sh' ran
    1.66 ± 0.01 times faster than './gen_mem1_sh.sh'
```

### Output
Both mem and mem2 produce near identical alignments. Only difference is in the header `@PG` line 

```bash

$ python ../bwameth.py --reference ../bwameth_idx/bwamem1/chm13.draft_v1.1.fasta ../fastq/R1.fq.gz ../fastq/R2.fq.gz > mem1.sam

$ python ../bwameth.py --reference ../bwameth_idx/bwamem2/chm13.draft_v1.1.fasta ../fastq/R1.fq.gz ../fastq/R2.fq.gz > mem2.sam


$ diff mem1.sam mem2.sam 
26c26
< @PG	ID:bwa-meth	PN:bwa-meth	VN:0.2.2	CL:"../bwameth.py --reference ../bwameth_idx/bwamem1/chm13.draft_v1.1.fasta ../fastq/R1.fq.gz ../fastq/R2.fq.gz"
---
> @PG	ID:bwa-meth	PN:bwa-meth	VN:0.2.2	CL:"../bwameth.py --reference ../bwameth_idx/bwamem2/chm13.draft_v1.1.fasta ../fastq/R1.fq.gz ../fastq/R2.fq.gz"

```

### Summary

Aligning with MEM2 is ~66% faster than the MEM1 with identical alignment.


My python isn't super good but these changes don't seem to break any existing changes and woks fine. 
Hope this will help many others like me who is or planning to migrate to MEM2 for speed.

Thank for all your awesome work :)