### PR TITLE
use raw string for regex pattern string

### DIFF
--- a/bwameth.py
+++ b/bwameth.py
@@ -314,7 +314,7 @@ class Bam(object):
     def ga_ct(self):
         return [x for x in self.other if x.startswith("YC:Z:")]
 
-    def longest_match(self, patt=re.compile("\d+M")):
+    def longest_match(self, patt=re.compile(r"\d+M")):
         return max(int(x[:-1]) for x in patt.findall(self.cigar))
 
 


### PR DESCRIPTION
Unescaped backslash of the regex pattern generates a SyntaxWarning at the moment, but according to python docs it will become a SyntaxError in the future.