### PR TITLE
Use tab separator in c2t to fix FASTQ comment tag propagation

### DIFF
--- a/bwameth.py
+++ b/bwameth.py
@@ -171,8 +171,8 @@ def convert_and_write_read(name,seq,qual,read_i,out):
     char_a, char_b = ['CT', 'GA'][read_i]
     # keep original sequence as name.
     name = "\t".join((name,
-                     "YS:Z:" + seq +
-                     "\tYC:Z:" + char_a + char_b + '\n'))
+                     "YS:Z:" + seq,
+                     "YC:Z:" + char_a + char_b)) + '\n'
     seq = seq.replace(char_a, char_b)
     out.write("".join((name, seq, "\n+\n", qual)))
 

--- a/bwameth.py
+++ b/bwameth.py
@@ -170,7 +170,7 @@ def convert_and_write_read(name,seq,qual,read_i,out):
 
     char_a, char_b = ['CT', 'GA'][read_i]
     # keep original sequence as name.
-    name = " ".join((name,
+    name = "\t".join((name,
                      "YS:Z:" + seq +
                      "\tYC:Z:" + char_a + char_b + '\n'))
     seq = seq.replace(char_a, char_b)


### PR DESCRIPTION
Hi there,

I have a workflow where I would like to maintain RX tags for UMIs to the aligned bams. I am trying to add the RX tags from ubams to fastqs with `samtools fastq -T RX` which adds them as a tab-separated comment.  It seems like bwameth is set up to use -C with bwa-mem to copy fastq comments. 

Currently the c2t function uses "".join to add the YS:Z: tag to the read name and since the fastq has a tab-separated comment there is a mixed-whitespace string e.g. @readname\tRX:Z:ACTG YS:Z:seq\tYC:Z:CT, and then bwa-mem copies everything after the first whitespace, so the tags end up squished together and bwameth can't parse the YS:Z: field and we get a StopIteration error.  Switching to "\t" looks like it will work -- I tested it on a fastq with the RX tags. 

Let me know if this seems reasonable.
Thanks!
Laura